### PR TITLE
#28 single request for ProjectList to core server

### DIFF
--- a/services/entity-server/package.json
+++ b/services/entity-server/package.json
@@ -10,6 +10,7 @@
     "axios": "^0.19.2",
     "connected-react-router": "^6.7.0",
     "history": "^4.10.1",
+    "jsonld": "^3.0.1",
     "prettier": "^1.19.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/services/entity-server/src/middleware/data-framing.js
+++ b/services/entity-server/src/middleware/data-framing.js
@@ -1,0 +1,9 @@
+import * as jsonld from "jsonld";
+
+export const constructFrame = (response, type) => ({
+        "@context": response["@context"],
+        "@type": type,
+        "@embed": "@always" //to nest duplicate URIs, e. g. the inspirations 
+    })
+
+export const frameData = (data, type) => jsonld.frame(data, constructFrame(data, type))

--- a/services/entity-server/src/middleware/data-transforms.js
+++ b/services/entity-server/src/middleware/data-transforms.js
@@ -77,7 +77,7 @@ export const extractSearchResults = data =>
   }));
 
 export const extractProjectList = data =>
-  data.ideaContests.map(ideaContest => ({
+  data["@graph"].map(ideaContest => ({
     id: ideaContest["@id"],
     description: ideaContest.description,
     title: ideaContest.title

--- a/services/entity-server/src/middleware/requests.js
+++ b/services/entity-server/src/middleware/requests.js
@@ -5,6 +5,10 @@ import {
   extractProjectList,
   extractSearchResults
 } from "./data-transforms";
+import {sparqlProjectListParams} from "./sparql-queries"
+import {frameData} from "./data-framing"
+
+const backendServiceBaseUrl = "https://innovonto-core.imp.fu-berlin.de/management/core/query";
 
 export const requestSearchData = (requestValue, dispatch) => {
   dispatch({
@@ -40,9 +44,14 @@ export const requestSessionData = dispatch => {
 
 export const requestProjectListData = dispatch => {
   axios
-    .get(process.env.PUBLIC_URL + "/data/mockdata-projects-list.json")
+    .get(backendServiceBaseUrl, sparqlProjectListParams())
     .then(result => {
-      dispatch(extractProjectList(result.data));
+      frameData(result.data, "gi2mo:IdeaContest")
+      
+      .then(data => {
+        console.log(data)
+        dispatch(extractProjectList(data))
+      })
     })
     .catch(error => {
       //TODO: make all components redirect to error page in a unified fashion <- input required

--- a/services/entity-server/src/middleware/requests.js
+++ b/services/entity-server/src/middleware/requests.js
@@ -47,9 +47,7 @@ export const requestProjectListData = dispatch => {
     .get(backendServiceBaseUrl, sparqlProjectListParams())
     .then(result => {
       frameData(result.data, "gi2mo:IdeaContest")
-      
       .then(data => {
-        console.log(data)
         dispatch(extractProjectList(data))
       })
     })

--- a/services/entity-server/src/middleware/sparql-queries.js
+++ b/services/entity-server/src/middleware/sparql-queries.js
@@ -19,8 +19,8 @@ const sparqlProjectList = () => (`
 
     CONSTRUCT  {
         ?project a gi2mo:IdeaContest ;
-                dcterms:numberIdeas ?ideaCount;
-                dcterms:numberUsers ?userCount;
+                inov:numberIdeas ?ideaCount;
+                inov:numberUsers ?userCount;
                 dcterms:title ?titel;
                 dcterms:description ?description;
                 rdfs:seeAlso ?seeAlso;

--- a/services/entity-server/src/middleware/sparql-queries.js
+++ b/services/entity-server/src/middleware/sparql-queries.js
@@ -1,0 +1,64 @@
+
+export const sparqlProjectListParams = () => coreServerRequest(sparqlProjectList())
+
+const coreServerRequest = sparqlQuery => {
+    return ( {
+        params: {
+            query: sparqlQuery,
+            format: "json"
+        }
+    })
+}
+
+const sparqlProjectList = () => (`
+    PREFIX gi2mo:<http://purl.org/gi2mo/ns#>
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+    PREFIX inov:<http://purl.org/innovonto/types/#>
+    PREFIX dcterms: <http://purl.org/dc/terms/>
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+    CONSTRUCT  {
+        ?project a gi2mo:IdeaContest ;
+                dcterms:numberIdeas ?ideaCount;
+                dcterms:numberUsers ?userCount;
+                dcterms:title ?titel;
+                dcterms:description ?description;
+                rdfs:seeAlso ?seeAlso;
+                dcterms:created	?created;
+                gi2mo:endDate ?endDate;
+                gi2mo:startDate ?startDate;
+    }			
+    WHERE { 
+    {
+        SELECT * WHERE {
+            ?project a gi2mo:IdeaContest;
+                dcterms:title ?titel;
+                rdfs:comment ?comment;
+                dcterms:description ?description;
+                rdfs:seeAlso ?seeAlso;
+                dcterms:created	?created;
+                gi2mo:endDate ?endDate;
+                gi2mo:startDate ?startDate;
+        }
+    }
+    UNION
+    {
+    SELECT ?project (COUNT(?idea) as ?ideaCount) (COUNT(?user) as ?userCount) WHERE {
+        {
+    ?project a gi2mo:IdeaContest;
+    OPTIONAL {
+        ?idea a gi2mo:Idea;
+            gi2mo:hasIdeaContest ?project.
+        
+        }
+    } UNION {
+    ?project a gi2mo:IdeaContest;
+    OPTIONAL {
+        ?user a inov:Ideator;
+            inov:hasSubmittedIdeasForIdeaContest ?project.
+            }
+        } 
+    }
+    GROUP BY ?project
+    }
+}`)

--- a/services/entity-server/yarn.lock
+++ b/services/entity-server/yarn.lock
@@ -2536,6 +2536,11 @@ caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001020, can
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001027.tgz#283e2ef17d94889cc216a22c6f85303d78ca852d"
   integrity sha512-7xvKeErvXZFtUItTHgNtLgS9RJpVnwBlWX8jSo/BO8VsF6deszemZSkJJJA1KOKrXuzZH4WALpAJdq5EyfgMLg==
 
+canonicalize@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/canonicalize/-/canonicalize-1.0.1.tgz#657b4f3fa38a6ecb97a9e5b7b26d7a19cc6e0da9"
+  integrity sha512-N3cmB3QLhS5TJ5smKFf1w42rJXWe6C1qP01z4dxJiI5v269buii4fLHWETDyf7yEd0azGLNC63VxNMiPd2u0Cg==
+
 capture-exit@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/capture-exit/-/capture-exit-2.0.0.tgz#fb953bfaebeb781f62898239dabb426d08a509a4"
@@ -6087,6 +6092,19 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
+jsonld@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/jsonld/-/jsonld-3.0.1.tgz#db32320fd9ccba843773bda3fcbcc938aac61b96"
+  integrity sha512-/lLx3sSvlqKHu3215+n4Fcmz7Ah8bixVa91CnXpW8XFZd6qCfAMQi/qEYF3u9fghKNqHjAD0TwCUH7fg6IszYg==
+  dependencies:
+    canonicalize "^1.0.1"
+    lru-cache "^5.1.1"
+    object.fromentries "^2.0.2"
+    rdf-canonize "^1.0.2"
+    request "^2.88.0"
+    semver "^6.3.0"
+    xmldom "0.1.19"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -6729,6 +6747,11 @@ node-forge@0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.0.tgz#d624050edbb44874adca12bb9a52ec63cb782579"
   integrity sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==
+
+node-forge@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.9.1.tgz#775368e6846558ab6676858a4d8c6e8d16c677b5"
+  integrity sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ==
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -8334,6 +8357,14 @@ raw-body@2.4.0:
     http-errors "1.7.2"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
+
+rdf-canonize@^1.0.2:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/rdf-canonize/-/rdf-canonize-1.1.0.tgz#61d1609bbdb3234b8f38c9c34ad889bf670e089d"
+  integrity sha512-DV06OnhVfl2zcZJQCt+YvU+hoZVgpyQpNFLeAmghq8RJybUxD3B4LRzlBquYS5k+LLd8/c3g5Gnhkqjw5qRMvg==
+  dependencies:
+    node-forge "^0.9.1"
+    semver "^6.3.0"
 
 react-app-polyfill@^1.0.6:
   version "1.0.6"
@@ -10671,6 +10702,11 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmldom@0.1.19:
+  version "0.1.19"
+  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.19.tgz#631fc07776efd84118bf25171b37ed4d075a0abc"
+  integrity sha1-Yx/Ad3bv2EEYvyUXGzftTQdaCrw=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
 includes framing and sparql-query. 

Note: the response keys from the number counts are comming in this format: 
```
"inov:numberIdeas": 605
"inov:numberUsers": 0
```
maybe include these property names (numberIdeas, numberUsers) in our purl name-space? @mackeprm 

Issue #28 is complete. Next connections to integrate could be search-Ideas and session-Data from gitlab repo i2m-2020

and I got some Warning when adding jsonld, but everything seems fine 


`warning " > @testing-library/user-event@7.2.1" has unmet peer dependency "@testing-library/dom@>=5".
warning " > connected-react-router@6.7.0" has unmet peer dependency "immutable@^3.8.1 || ^4.0.0-rc.1".
warning " > connected-react-router@6.7.0" has unmet peer dependency "react-redux@^6.0.0 || ^7.1.0".
warning " > connected-react-router@6.7.0" has unmet peer dependency "react-router@^4.3.1 || ^5.0.0".
warning " > connected-react-router@6.7.0" has unmet peer dependency "seamless-immutable@^7.1.3".
warning "react-scripts > eslint-config-react-app@5.2.0" has incorrect peer dependency "eslint-plugin-flowtype@3.x".
warning "react-scripts > @typescript-eslint/eslint-plugin > tsutils@3.17.1" has unmet peer dependency "typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta".
[4/4] 🔨  Building fresh packages...
warning Error running install script for optional dependency: "/Users/lukastaerk/Projects/Innovonto-Core/services/entity-server/node_modules/fsevents: Command failed.
Exit code: 1`
